### PR TITLE
digest transport not sending http.Request.Body

### DIFF
--- a/gae/ns/digest/digest.go
+++ b/gae/ns/digest/digest.go
@@ -49,6 +49,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -232,6 +233,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, ErrNilTransport
 	}
 
+	// Cache Original Body
+	cachedBody, _ := ioutil.ReadAll(req.Body)
+	fmt.Printf("Request: %s\n", string(cachedBody))
+	req.Body = ioutil.NopCloser(bytes.NewReader(cachedBody))
+
 	// Copy the request so we don't modify the input.
 	req2 := new(http.Request)
 	*req2 = *req
@@ -260,6 +266,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Make authenticated request.
 	req2.Header.Set("Authorization", auth)
+	req2.Body = ioutil.NopCloser(bytes.NewReader(cachedBody))
 	return t.Transport.RoundTrip(req2)
 }
 

--- a/gae/ns/digest/digest.go
+++ b/gae/ns/digest/digest.go
@@ -235,8 +235,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// Cache Original Body
-	cachedBody, _ := ioutil.ReadAll(req.Body)
-	req.Body = ioutil.NopCloser(bytes.NewReader(cachedBody))
+	var cachedBody []byte
+	if req.Body != nil {
+		cachedBody, _ = ioutil.ReadAll(req.Body)
+		req.Body = ioutil.NopCloser(bytes.NewReader(cachedBody))
+	}
 
 	// Copy the request so we don't modify the input.
 	req2 := new(http.Request)
@@ -266,7 +269,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Make authenticated request.
 	req2.Header.Set("Authorization", auth)
-	req2.Body = ioutil.NopCloser(bytes.NewReader(cachedBody))
+	if len(cachedBody) > 0 {
+		req2.Body = ioutil.NopCloser(bytes.NewReader(cachedBody))
+	}
 	return t.Transport.RoundTrip(req2)
 }
 

--- a/gae/ns/digest/digest.go
+++ b/gae/ns/digest/digest.go
@@ -44,6 +44,7 @@
 package digest
 
 import (
+	"bytes"
 	"crypto/md5"
 	"crypto/rand"
 	"errors"

--- a/gae/ns/digest/digest.go
+++ b/gae/ns/digest/digest.go
@@ -236,7 +236,6 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Cache Original Body
 	cachedBody, _ := ioutil.ReadAll(req.Body)
-	fmt.Printf("Request: %s\n", string(cachedBody))
 	req.Body = ioutil.NopCloser(bytes.NewReader(cachedBody))
 
 	// Copy the request so we don't modify the input.


### PR DESCRIPTION
fixed bug where a body provided to the digest transport gets wiped for the fully authenticated request to the host